### PR TITLE
Fix/seed add missing param

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "numpy>=1.26",
     "omegaconf>=2.3",
     "scikit-learn>=1.4",
-    "matplotlib>=3.8"
+    "matplotlib>=3.8",
     ]
 
 [project.scripts]
@@ -22,6 +22,7 @@ dev = [
     "ruff>=0.5",
     "black>=24.8",
     "isort>=5.13"
+    "commitizen>=0",
     ]
 
 torch-cpu = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ dev = [
     "pre-commit>=3.7",
     "ruff>=0.5",
     "black>=24.8",
-    "isort>=5.13"
-    "commitizen>=0",
+    "isort>=5.13",
     ]
 
 torch-cpu = [

--- a/src/ablation_harness/seed_utils.py
+++ b/src/ablation_harness/seed_utils.py
@@ -1,15 +1,24 @@
 import os
 import random
+from typing import Optional
 
 import numpy as np
 import torch
 
 
-def seed_everything(seed: int, single_thread: bool = True) -> torch.Generator:
+def seed_everything(seed: int, single_thread: bool = True, deterministic: bool = True, cudnn_benchmark: Optional[bool] = None) -> torch.Generator:
+    """
+    Seed all RNGs and (optionally) force deterministic algorithms.
+    Call this ONCE at the very start of a run.
+    """
+    # Python / NumPy
     os.environ["PYTHONHASHSEED"] = str(seed)
     random.seed(seed)
     np.random.seed(seed)
+
+    # Torch
     torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
 
     if single_thread:
         torch.set_num_threads(1)
@@ -18,12 +27,21 @@ def seed_everything(seed: int, single_thread: bool = True) -> torch.Generator:
         os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
         os.environ.setdefault("NUMEXPR_NUM_THREADS", "1")
 
-    # GPU safety if you ever enable it
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(seed)
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
+    if deterministic:
+        # Make PyTorch pick deterministic kernals
         torch.use_deterministic_algorithms(True)
+        # cuDNN knobs (harmless on CPU)
+        torch.backends.cudnn.deterministic = True
+        # Benchmark should be off for determinisum you explicitly want speed
+        torch.backends.cudnn.benchmark = False if cudnn_benchmark is None else cudnn_benchmark
+
+        # For CUDA matmul determinisum on some stacks; set **before** CUDA context creation ideally
+        os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    else:
+        torch.backends.cudnn.deterministic = False
+        # Let user choose whether to enable autotuner when not strict-deterministic
+        if cudnn_benchmark is not None:
+            torch.backends.cudnn.benchmark = cudnn_benchmark
 
     g = torch.Generator()
     g.manual_seed(seed)
@@ -31,7 +49,21 @@ def seed_everything(seed: int, single_thread: bool = True) -> torch.Generator:
     return g
 
 
-def seed_worker(worker_id: int):
-    worker_seed = torch.initial_seed() % 2**32
-    np.random.seed(worker_seed)
-    random.seed(worker_seed)
+def seed_worker(base_seed: int):
+    """Use in DataLoader so each worker has a distinct, reproducible seed."""
+
+    def _init(worker_id: int):
+        worker_seed = (base_seed + worker_id) % (2**32)
+        np.random.seed(worker_seed)
+        random.seed(worker_seed)
+        torch.manual_seed(worker_seed)
+
+    worker_seed = _init(base_seed)
+    return worker_seed
+
+
+# unused for now; makes a generator (e.g. for dataloaders)
+def make_generator(seed: int) -> torch.Generator:
+    g = torch.Generator()
+    g.manual_seed(seed)
+    return g

--- a/tests/test_plot_loss.py
+++ b/tests/test_plot_loss.py
@@ -8,6 +8,9 @@ Covers:
 - --ylim enforcement + summary printing (import module, no subprocess)
 - Auto-zoom behavior for nearly-flat series (import module)
 
+
+UNTESTED for csv input outside these tests.
+
 """
 
 import csv


### PR DESCRIPTION
This --seed param allows easy commandline override:

seed precedence rule:
    If --seed is provided → use that seed only (remove grid.seed).
    Else if grid.seed exists → sweep those seeds.
    Else use base.seed (default).

Example:
    python -m ablation_harness.ablate --config configs/tiny_cifar.yaml --out_dir runs/cifar_tiny --seed 799